### PR TITLE
Added module retraction for version v1.0.2 and v3.2.0-incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,8 @@ module github.com/dgrijalva/jwt-go
 
 go 1.14
 
+// this version suffers from CVE-2020-26160 and follows a pre-modules versioning scheme
+retract v3.2.0+incompatible
+
+// this version was a leftover from the original versioning scheme and got cached by accident
+retract v1.0.2


### PR DESCRIPTION
It seems that two old versions were indexed by the golang mirror. This
will retract them, but I fear that this only works for Go 1.16.
